### PR TITLE
Update localmedia.py

### DIFF
--- a/Contents/Code/support/localmedia.py
+++ b/Contents/Code/support/localmedia.py
@@ -159,7 +159,7 @@ def find_subtitles(part):
                 continue
 
         # determine whether to pick up the subtitle based on our match strictness
-        elif not filename_matches_part:
+        if not filename_matches_part:
             if sz_config.ext_match_strictness == "strict" or (
                             sz_config.ext_match_strictness == "loose" and not filename_contains_part):
                 # Log.Debug("%s doesn't match %s, skipping" % (helpers.unicodize(local_filename),


### PR DESCRIPTION
There is an issue with subtitle ignoring ext_match_strictness if a custom subtitle folder is defined. Some other people have noted it (https://www.reddit.com/r/PlexACD/comments/6ileio/has_anyone_of_you_found_a_way_to_have_subzero/djphdly/).
I looked at the code and the issue is: if adding a custom subtitle absolute path folder, global_folders will be true and if filename_matches_part is false, the flow will go through this if case:
if global_folders and not filename_matches_part:
but now if the matching file is not in a global folder skip_path is false and the flow will continue, though it should still check match strictness in the next code.
If we change elif to if all will be fine, files that are matching but not in global folders will still go through regular processing and use the strictness defined.