### PR TITLE
Refactor the fix_inconsistent_naming function for hosszupuska.

### DIFF
--- a/Contents/Libraries/Shared/subliminal_patch/providers/hosszupuska.py
+++ b/Contents/Libraries/Shared/subliminal_patch/providers/hosszupuska.py
@@ -34,7 +34,7 @@ def fix_inconsistent_naming(title):
     """
     return _fix_inconsistent_naming(title, {"Stargate Origins": "Stargate: Origins",
                                             "Marvel's Agents of S.H.I.E.L.D.": "Marvels+Agents+of+S.H.I.E.L.D",
-                                            "Mayans M.C.": "Mayans MC"})
+                                            "Mayans M.C.": "Mayans MC"}, True )
 
 
 logger = logging.getLogger(__name__)

--- a/Contents/Libraries/Shared/subliminal_patch/providers/titlovi.py
+++ b/Contents/Libraries/Shared/subliminal_patch/providers/titlovi.py
@@ -41,8 +41,8 @@ def fix_inconsistent_naming(title):
     :rtype: str
 
     """
-    return sanitize(_fix_inconsistent_naming(title, {"DC's Legends of Tomorrow": "Legends of Tomorrow",
-                                            "Marvel's Jessica Jones": "Jessica Jones"}))
+    return _fix_inconsistent_naming(title, {"DC's Legends of Tomorrow": "Legends of Tomorrow",
+                                            "Marvel's Jessica Jones": "Jessica Jones"})
 
 logger = logging.getLogger(__name__)
 

--- a/Contents/Libraries/Shared/subliminal_patch/utils.py
+++ b/Contents/Libraries/Shared/subliminal_patch/utils.py
@@ -35,11 +35,12 @@ def sanitize(string, ignore_characters=None, default_characters={'-', ':', '(', 
     return string.strip().lower()
 
 
-def fix_inconsistent_naming(title, inconsistent_titles_dict=None):
+def fix_inconsistent_naming(title, inconsistent_titles_dict=None, no_sanitize=False):
     """Fix titles with inconsistent naming using dictionary and sanitize them.
 
     :param str title: original title.
     :param dict inconsistent_titles_dict: dictionary of titles with inconsistent naming.
+    :param bool no_sanitize: indication to not sanitize title.
     :return: new title.
     :rtype: str
 
@@ -54,5 +55,9 @@ def fix_inconsistent_naming(title, inconsistent_titles_dict=None):
         pattern = re.compile('|'.join(re.escape(key) for key in inconsistent_titles_dict.keys()))
         title = pattern.sub(lambda x: inconsistent_titles_dict[x.group()], title)
 
+    if no_sanitize:
+        return title
+    else:
+        return sanitize(title)
     # return fixed and sanitized title
     return title


### PR DESCRIPTION
I create some improvments for hosszupuska Provider.

The problem that there are some inconsistent_naming on the provider like:
Stargate: Origins

But for this I need to modify the function _fix_inconsistent_naming from util to dont done sanitize().
(Becuse it remove the : from the name)