### PR TITLE
Fix issue scandir not returning the name of the file inside Docker

### DIFF
--- a/Contents/Libraries/Shared/subliminal_patch/core.py
+++ b/Contents/Libraries/Shared/subliminal_patch/core.py
@@ -559,6 +559,9 @@ def _search_external_subtitles(path, languages=None, only_one=False, scandir_gen
     subtitles = {}
     _scandir = _scandir_generic if scandir_generic else scandir
     for entry in _scandir(dirpath):
+        if not entry.name and not scandir_generic:
+            logger.debug('Could not determine the name of the file, retrying with scandir_generic')
+            return _search_external_subtitles(path, languages, only_one, True)
         if not entry.is_file(follow_symlinks=False):
             continue
 


### PR DESCRIPTION
This code change fixes my docker image on raspberry pi not finding any external subs, due to scandir returning a generator with empty file names. The issue is described in detail over here: https://github.com/morpheus65535/bazarr/issues/334