### PR TITLE
Allow matching either series name or imdb_id

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -23,7 +23,7 @@
         <key>PlexPluginConsoleLogging</key>
         <string>0</string>
         <key>PlexPluginDevMode</key>
-        <string>1</string>
+        <string>0</string>
          <key>PlexPluginCodePolicy</key>
             <!-- this allows channels to access some python methods which are otherwise blocked, as well as import external code libraries, and interact with the PMS HTTP API -->
             <string>Elevated</string>
@@ -32,7 +32,7 @@
 
 &lt;h1&gt;Sub-Zero for Plex&lt;/h1&gt;&lt;i&gt;Subtitles done right&lt;/i&gt;
 
-Version 2.6.5.2997 DEV
+Version 2.6.5.2997
 
 Originally based on @bramwalet's awesome &lt;a href=&quot;https://github.com/bramwalet/Subliminal.bundle&quot;&gt;Subliminal.bundle&lt;/a&gt;
 

--- a/Contents/Libraries/Shared/subliminal_patch/core.py
+++ b/Contents/Libraries/Shared/subliminal_patch/core.py
@@ -396,7 +396,12 @@ class SZProviderPool(ProviderPool):
                 if not subtitle.hash_verifiable and "hash" in matches:
                     can_verify_series = False
 
-                if can_verify_series and not {"series", "season", "episode"}.issubset(orig_matches):
+                matches_series = False
+                if {"season", "episode"}.issubset(orig_matches) and \
+                                ("series" in orig_matches or "imdb_id" in orig_matches):
+                    matches_series = True
+
+                if can_verify_series and not matches_series:
                     logger.debug("%r: Skipping subtitle with score %d, because it doesn't match our series/episode",
                                  subtitle, score)
                     continue


### PR DESCRIPTION
I noticed Sub-Zero was unable to download subtitles for the series "Marvel's Cloak & Dagger", even though multiple subtitles were available.
The issue is in the naming of the series. In Plex the series is called "Marvel's Cloak & Dagger", but on opensubtitles.org it's called "Cloak & Dagger", resulting in a mismatch on series name.

These changes don't require the series name to be a match if the imdb_id is a match.