### PR TITLE
Update drone api endpoint

### DIFF
--- a/Contents/Libraries/Shared/subliminal_patch/refiners/drone.py
+++ b/Contents/Libraries/Shared/subliminal_patch/refiners/drone.py
@@ -36,8 +36,8 @@ class DroneAPIClient(object):
         if not base_url.startswith("http"):
             base_url = "http://%s" % base_url
 
-        if not base_url.endswith("api/"):
-            self.api_url = urljoin(base_url, "api/")
+        if not base_url.endswith("api/v3/"):
+            self.api_url = urljoin(base_url, "api/v3/")
 
     def get_guess(self, video, scene_name):
         raise NotImplemented


### PR DESCRIPTION
sure not the most elegant way (should be configured or better guessed) but this way we re-enable refiners on new instances of Sonarr and Radarr that otherwise returns 404 (/api/movie)